### PR TITLE
adds code climate yml file to ignore tests in maintainability score

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+version: "2"
+exclude_patterns:
+  - "**/__tests__/"


### PR DESCRIPTION
# Description
Addes a .codeclimate.yml file to ignore files with the pathway /__tests__/
Fixes #47 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Change Status

- [x] Complete, but not tested (may need new tests)


# How Has This Been Tested?

- [x] excludes files with the pathway of "/__tests__/" which is where all of our tests are stored.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
