### PR TITLE
Double click on "Go" issue

### DIFF
--- a/src/organisms/LocationsPage.jsx
+++ b/src/organisms/LocationsPage.jsx
@@ -76,12 +76,10 @@ const CardsContainer = styled.div`
 `;
 
 const Img = styled.img`
-
   margin-top: 108px;
   margin-bottom: 150px;
 
   // width: 50px;
-  
 `;
 
 function validateZip(zip) {
@@ -102,8 +100,8 @@ function renderLocations(locations) {
       ))}
     </CardsContainer>
   ) : (
-      <Img src={walkingImage} />
-    );
+    <Img src={walkingImage} />
+  );
 }
 
 const LocationsPage = () => {
@@ -177,7 +175,6 @@ const LocationsPage = () => {
       postalInfo.variables.postal_code &&
       postalInfo.variables.postal_code === zip
     ) {
-      alert("Change the damn zip code");
       return;
     }
 


### PR DESCRIPTION
changed secondary click on Go for locations to just return, negating negative effects but removing the alert message

# Description

Partially Fixes 73

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [X] npm run start

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
