### PR TITLE
Bug/154

### DIFF
--- a/src/molecules/HomeSearchBar.jsx
+++ b/src/molecules/HomeSearchBar.jsx
@@ -69,6 +69,7 @@ const DropListItem = styled.li`
   width: 100%;
   margin-left: 9%;
 `;
+const FilteredContainer = styled.div``;
 
 const GET_MATERIALS = gql`
   query getAllMaterials {
@@ -155,9 +156,11 @@ const HomeSearchBar = ({ searchFocus, setSearchFocus }) => {
           onChange={e => setSearchTerm(e.target.value)}
         />
       </SearchContainer>
-      <div style={{ display: filtered.length === 0 ? "none" : null }}>
+      <FilteredContainer
+        style={{ display: filtered.length === 0 ? "none" : null }}
+      >
         {renderFiltered()}
-      </div>
+      </FilteredContainer>
       {/* <Toggle toggleTheme={toggleTheme} theme={theme} /> */}
     </SearchPageContainer>
   );

--- a/src/molecules/HomeSearchBar.jsx
+++ b/src/molecules/HomeSearchBar.jsx
@@ -101,13 +101,11 @@ const HomeSearchBar = ({ searchFocus, setSearchFocus }) => {
       setFiltered(newList);
     }
   }, [searchTerm]);
-
   // sets the selected suggestion to be the search term
   const search = value => {
     const foundMaterial = data.materials.filter(mat =>
       mat.description.toLowerCase().includes(value.toLowerCase())
     )[0];
-    console.log(foundMaterial);
     history.push(`/material/${foundMaterial.material_id}`);
   };
 
@@ -140,7 +138,14 @@ const HomeSearchBar = ({ searchFocus, setSearchFocus }) => {
 
   return (
     <SearchPageContainer>
-      <SearchContainer onSubmit={handleSubmit} searchTerm={searchTerm}>
+      <SearchContainer
+        onSubmit={handleSubmit}
+        searchTerm={searchTerm}
+        style={{
+          borderRadius:
+            searchTerm !== "" && filtered.length === 0 ? "20px" : null
+        }}
+      >
         <Img src={lensImg} alt="lens" />
         <InputField
           ref={searchBarRef}
@@ -150,7 +155,9 @@ const HomeSearchBar = ({ searchFocus, setSearchFocus }) => {
           onChange={e => setSearchTerm(e.target.value)}
         />
       </SearchContainer>
-      {renderFiltered()}
+      <div style={{ display: filtered.length === 0 ? "none" : null }}>
+        {renderFiltered()}
+      </div>
       {/* <Toggle toggleTheme={toggleTheme} theme={theme} /> */}
     </SearchPageContainer>
   );


### PR DESCRIPTION
# Description

Having an invalid search term did not restore the search bar to its original border radius. This PR solves that by using inline conditional styling for the components

Fixes #154 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Empty search term sets the border radius to `20px` all corners. 

![Empty Search Term](https://user-images.githubusercontent.com/52539096/75372924-45a57a00-5897-11ea-91b0-a68af303a60c.png)

- [x] Entered Search Term with suggestions sets border radius to `20px 20px 0 0`

![Entered Search Term](https://user-images.githubusercontent.com/52539096/75373024-7a193600-5897-11ea-9c71-78d1a39492b2.png)

- [x] Entered Search Term without matching suggestion sets styling back to original `20px` all corners.

![invalid search match](https://user-images.githubusercontent.com/52539096/75373110-a7fe7a80-5897-11ea-9a7e-91ad4a6eff9f.png)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
