### PR TITLE
Dark mode bug removed from splash page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,6 +32,7 @@ const DesktopConstraint = styled.div`
   max-width: 1040px;
   width: 100%;
   margin: 0 auto;
+  background-color: white;
 `;
 
 export const GET_CATEGORIES = gql`
@@ -57,6 +58,12 @@ export const GET_MATERIALS = gql`
   }
 `;
 
+export function isDesktop() {
+  const vw = window.innerWidth;
+
+  return vw > 875;
+}
+
 const App = () => {
   const history = useHistory();
   const [theme, toggleTheme] = useDarkMode();
@@ -74,9 +81,7 @@ const App = () => {
     //remove persisted cache from apollo if exists
     localStorage.removeItem("apollo-cache-persist");
 
-    const vw = window.innerWidth;
-
-    if (vw > 875) {
+    if (isDesktop()) {
       history.push("/splash");
     } else {
       if (permissions && permissions.firstVisit === false) {

--- a/src/molecules/global.jsx
+++ b/src/molecules/global.jsx
@@ -1,7 +1,8 @@
 import { createGlobalStyle } from "styled-components";
+import { isDesktop } from "../App";
 
 export const GlobalStyles = createGlobalStyle`
     body {
-        background: ${({ theme }) => theme.body};
+        background: ${({ theme }) => (isDesktop() ? "#FFFFFF" : theme.body)};
     }
 `;


### PR DESCRIPTION
# Description

Fixed a bug where dark mode creeped through splash page.
Removed dark background all together from splash page as no support for dark mode for splash page is available.

Fixes #209 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
